### PR TITLE
Fix incorrect stack calculation

### DIFF
--- a/bike.js
+++ b/bike.js
@@ -125,7 +125,7 @@ function Bike (color,cvs, form) {
 	}
 
 	this.stack = function () {
-		return Math.sin(deg2rad(this.hta)) * (this.htl + this.fl - this.fo * Math.cos(deg2rad(this.hta))) + this.bbDrop;
+		return Math.sin(deg2rad(this.hta)) * (this.htl + this.fl) - this.fo * Math.cos(deg2rad(this.hta)) + this.bbDrop;
 	}
 	this.stackWithSpacers = function () {
 		return this.stack() + this.spacers * Math.sin(deg2rad(this.hta));


### PR DESCRIPTION
The stack calculation is incorrect. The stack due to fork offset should be moved outside of the group being multiplied by `sin(hta)` because it already accounts for hta.

That being said, stack/reach calculation with this app is already almost guaranteed to be off anyways because it doesn't seem to account for headset stack height? That should probably be added too.